### PR TITLE
Correct path to "callstats-jssip.min.js"

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 			setInterval(window.antiglobal, 5000);
 		</script>
 		<script src='https://api.callstats.io/static/callstats.min.js'></script>
-		<script src='resources/js/callstats-jssip.min.js'></script>
+		<script src='https://api.callstats.io/static/callstats-jssip.min.js'></script>
 
 		<script>
 			// Uncomment and fill the SETTINGS object in order to use hardcoded settings


### PR DESCRIPTION
Script "callstats-jssip.min.js" is missing at https://tryit.jssip.net/